### PR TITLE
Fix bug where requirements was overwritten instead of appended

### DIFF
--- a/mangum_cli/commands.py
+++ b/mangum_cli/commands.py
@@ -72,7 +72,7 @@ def init(name: str, bucket_name: str = None, region_name: str = None) -> None:
     with open(os.path.join(config_dir, "mangum.yml"), "w") as f:
         config_data = yaml.dump(config, default_flow_style=False, sort_keys=False)
         f.write(config_data)
-    with open(os.path.join(config_dir, "requirements.txt"), "w") as f:
+    with open(os.path.join(config_dir, "requirements.txt"), "a") as f:
         f.write("mangum\n")
     click.echo(f"Configuration saved to: {config_dir}")
 


### PR DESCRIPTION
Previously the requirements.txt was overwritten by `mangum init` when mangum was added.
Now mangum is appended instead.