### PR TITLE
Enable shell completion with tab key.

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,23 @@ Run the following command to delete the CloudFormation stack:
 mangum delete
 ```
 
-### Appendix - `build`, `package`, and `deploy`:
+### Appendix.A - Enable shell completion.
+
+You can enable shell completion by running the install option.
+
+```shell
+mangum complement bash
+```
+
+Candidates can be displayed by pressing the tab key.
+
+```sh
+$ mangum [TAB][TAB]
+all            complement     delete         describe       package
+build          create-bucket  deploy         init           validate
+```
+
+### Appendix.B - `build`, `package`, and `deploy`.
 
 If you want to execute build, package, and deploy sequentially, do as follows:
 

--- a/mangum_cli/commands.py
+++ b/mangum_cli/commands.py
@@ -5,11 +5,36 @@ import uuid
 
 import boto3
 import click
+import click_completion
+import click_completion.core
 from botocore.exceptions import ClientError
 
 import yaml
 from mangum_cli.config import Config
 
+
+def custom_startswith(string, incomplete):
+    """
+    A custom completion matching that supports case insensitive matching
+    """
+    if os.environ.get('_CLICK_COMPLETION_COMMAND_CASE_INSENSITIVE_COMPLETE'):
+        string = string.lower()
+        incomplete = incomplete.lower()
+    return string.startswith(incomplete)
+
+
+click_completion.core.startswith = custom_startswith
+click_completion.init()
+cmd_help = """Shell completion for click-completion-command
+
+Available shell types:
+
+\b
+  %s
+
+Default type: auto
+""" % "\n  ".join('{:<12} {}'.format(k, click_completion.core.shells[k]) for k in sorted(
+    click_completion.core.shells.keys()))
 
 @click.group()
 def mangum_cli() -> None:
@@ -213,6 +238,19 @@ def describe() -> None:
     config = get_config()
     config.describe()
 
+
+@mangum_cli.command()
+@click.option('--append/--overwrite', help="Append the completion code to the file", default=None)
+@click.option('-i', '--case-insensitive/--no-case-insensitive', help="Case insensitive completion")
+@click.argument('shell', required=False, type=click_completion.DocumentedChoice(click_completion.core.shells))
+@click.argument('path', required=False)
+def complement(append, case_insensitive, shell, path):
+    """
+    Install the click-completion-command completion.
+    """
+    extra_env = {'_CLICK_COMPLETION_COMMAND_CASE_INSENSITIVE_COMPLETE': 'ON'} if case_insensitive else {}
+    shell, path = click_completion.core.install(shell=shell, path=path, append=append, extra_env=extra_env)
+    click.echo('%s completion installed in %s' % (shell, path))
 
 # @mangum_cli.command()
 # def tail() -> None:

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     url="https://github.com/erm/mangum-cli",
     description="CLI tools for Mangum",
     long_description=get_long_description(),
-    install_requires=["awscli", "boto3", "click"],
+    install_requires=["awscli", "boto3", "click", "click_completion"],
     entry_points={"console_scripts": ["mangum = mangum_cli.__main__:main"]},
     long_description_content_type="text/markdown",
     author="Jordan Eremieff",


### PR DESCRIPTION
# Summary

Enable shell completion with pressing the tab key.

# Installation

Execute the following comment to enable shell completion.

```sh
mangum complement bash
```

# Usage

For example:

```sh
$ mangum [TAB][TAB]
all            complement     delete         describe       package
build          create-bucket  deploy         init           validate
```
